### PR TITLE
use react versions higher than 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "gh-pages": "^2.2.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.4",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "react-scripts": "^3.4.1"
+    "react": ">=16.13.1",
+    "react-dom": ">=16.13.1",
+    "react-scripts": ">=3.4.1"
   },
   "files": [
     "dist"


### PR DESCRIPTION
React was upgraded to version 18 while this package uses only react 16.x, with other versions the npm install fails.
This package.json semver change will allow using on all react version higher than 16.